### PR TITLE
Support python 3.8 and update readme with instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ But TSDF can fail in larger indoor room reconstructions. We reccommend Poisson f
 ### Generate pseudo ground truth normal maps
 The `dn-splatter` model's predicted normals can be supervised with the gradient of rendered depth maps or by external monocular normal estimates using the flag `--pipeline.model.normal-supervision (mono/depth)`. To train with monocular normals, you need to use an external network to predict them.
 
-We support generating low and hd monocular normal estimates from a pretrained [omnimodel](https://github.com/EPFL-VILAB/omnidata). You need to download the model weights first:
+We support generating low and hd monocular normal estimates from a pretrained [omnimodel](https://github.com/EPFL-VILAB/omnidata) and from [DSINE](https://github.com/pablovela5620). 
+
+
+#### 1. Omnidata normals:
+You need to download the model weights first:
 
 ```bash
 python dn_splatter/data/download_scripts/download_omnidata.py
@@ -147,10 +151,25 @@ python dn_splatter/scripts/normals_from_pretrain.py
 ```
 We highly reccommend using low res normal maps, since generating HD versions from omnidata (that match the dataset image size) is very time consuming.
 
+#### 2. DSINE normals:
+To generate normals from DSINE, run the following command:
+
+```bash
+python dn_splatter/scripts/normals_from_pretrain.py --data-dir [PATH_TO_DATA] --model-type dsine
+```
+
+If using DSINE normals for supervision, remember to use the `--normal-format opencv` in your `ns-train` command. An example command is as follows:
+
+```bash
+ns-train dn-splatter --pipeline.model.use-normal-loss True --pipeline.model.normal-supervision mono replica --data ./datasets/Replica/ --normals-from pretrained --normal-format opencv
+```
+
+#### Important notes:
 Default save path of generated normals is `data_root/normals_from_pretrain`
-And to enable training with pretrained normals, add `--normals_from pretrained` flag in the dataparser. 
+And to enable training with pretrained normals, add `--normals-from pretrained` flag in the dataparser. 
 
 NOTE: different monocular networks can use varying camera coordinate systems for saving/visualizing predicted normals in the camera frame. We support both OpenGL and OpenCV coordinate systems. Each dataparser has a flag `--normal-format [opengl/opencv]` to distinguish between them. We render normals into the camera frame according to OpenCV color coding which is similar to Open3D. Some software might have different conventions. Omnidata normals are stored in OpenGL coordinates, but we convert them to OpenCV for consistency across the repo.
+
 ### Convert dataset to COLMAP format
 
 If your dataset has no camera pose information, you can generate poses using COLMAP.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ But TSDF can fail in larger indoor room reconstructions. We reccommend Poisson f
 ### Generate pseudo ground truth normal maps
 The `dn-splatter` model's predicted normals can be supervised with the gradient of rendered depth maps or by external monocular normal estimates using the flag `--pipeline.model.normal-supervision (mono/depth)`. To train with monocular normals, you need to use an external network to predict them.
 
-We support generating low and hd monocular normal estimates from a pretrained [omnimodel](https://github.com/EPFL-VILAB/omnidata) and from [DSINE](https://github.com/pablovela5620). 
+We support generating low and hd monocular normal estimates from a pretrained [omnimodel](https://github.com/EPFL-VILAB/omnidata) and from [DSINE](https://github.com/baegwangbin/DSINE). 
 
 
 #### 1. Omnidata normals:

--- a/dn_splatter/scripts/dsine/dsine_predictor.py
+++ b/dn_splatter/scripts/dsine/dsine_predictor.py
@@ -1,7 +1,7 @@
 import os
 import torch
 import numpy as np
-from typing import Literal
+from typing import Literal, Optional
 from torchvision import transforms
 from jaxtyping import UInt8, Float
 import torch.nn.functional as F
@@ -49,7 +49,7 @@ def get_intrins_from_fov(new_fov, height, width, device):
     return new_intrins
 
 
-def _load_state_dict(local_file_path: str | None = None):
+def _load_state_dict(local_file_path: Optional[str] = None):
     if local_file_path is not None and os.path.exists(local_file_path):
         # Load state_dict from local file
         state_dict = torch.load(local_file_path, map_location=torch.device("cpu"))
@@ -85,7 +85,7 @@ class DSinePredictor:
     def __call__(
         self,
         rgb: UInt8[np.ndarray, "h w 3"],
-        K_33: Float[np.ndarray, "3 3"] | None = None,
+        K_33: Optional[Float[np.ndarray, "3 3"]] = None,
     ) -> Float[torch.Tensor, "b 3 h w"]:
         rgb = rgb.astype(np.float32) / 255.0
         rgb = torch.from_numpy(rgb).permute(2, 0, 1).unsqueeze(0).to(self.device)


### PR DESCRIPTION
Hi @pablovela5620, amazing stuff. I found one interesting bug, apparently the `|` operation is not supported in typing for python 3.8. See [this](https://stackoverflow.com/questions/76712720/typeerror-unsupported-operand-types-for-type-and-nonetype) for more details. 

Also updated the readme with a bit more instructions.